### PR TITLE
Prove Stream.mul preserves monotonicity

### DIFF
--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -283,7 +283,7 @@ end
 
 instance hmul.is_simple
 (a : Stream σ₁ ι α) (b : Stream σ₂ ι α)
-(ha : a.is_simple) (hb : b.is_simple) : (a.mul b).is_simple :=
+[ha : a.is_simple] [hb : b.is_simple] : (a.mul b).is_simple :=
 { monotonic := begin
     intros r h,
     cases h with ha_valid hb_valid,
@@ -556,6 +556,41 @@ instance hmul.is_simple
     { apply @is_simple.reduced _ _ _ _ _ hb; simp [*] },
   end
 }
+
+#check primitives.range 2
+
+instance primitives.range.is_simple (n : ℕ) : (primitives.range n).is_simple := {
+  monotonic := begin
+    intros ctr h_valid,
+    simp only [StreamState.lag, StreamState.to_order_tuple, StreamState.now', prod_le_iff],
+    cases em (n ≤ ctr + 1),
+    { left,
+      simp only [primitives.range] at ⊢ h_valid,
+      simp only [bool.lt_iff],
+      split; simpa },
+    { right, split,
+      { simp only [primitives.range] at ⊢ h_valid,
+        simp [h_valid, lt_of_not_le h] },
+      { left, split_ifs,
+        { simp [with_top.coe_lt_coe, primitives.range] },
+        { apply with_top.coe_lt_top },
+        { contradiction },
+        { apply with_top.coe_lt_top } } }
+  end,
+
+  reduced := begin
+    intros s t hs ht ready_s ready_t eq,
+    cases ready_s,
+    cases ready_t,
+
+    simp only [primitives.range] at eq,
+    assumption
+  end,
+}
+
+example : (primitives.range 2).is_simple := by apply_instance
+example : ((primitives.range 2).mul (primitives.range 3)).is_simple := by apply_instance
+example : (((primitives.range 2).mul (primitives.range 3)).mul (primitives.range 4)).is_simple := by apply_instance
 
 variables
 (a_simple : a.is_simple)

--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -313,7 +313,7 @@ instance hmul.is_simple
       replace valid_eq : a.valid r.fst ↔ a.valid (a.next r.fst ha_valid) :=
         by simpa only [bool_not_iff, bool.of_to_bool_iff, bool.to_bool_not, bool.to_bool_eq] using valid_eq,
 
-      have ha_valid_post : a.valid (a.next r.fst _) := valid_eq.mp ha_valid,
+      have ha_valid' : a.valid (a.next r.fst _) := valid_eq.mp ha_valid,
 
       rw prod_le_iff at |- hh,
       right, rw prod_le_iff,
@@ -368,7 +368,7 @@ instance hmul.is_simple
         -- Various impossible cases (either a or b is invalid).
         all_goals {
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h_1,
-            from absurd hb_valid (h_1 ha_valid_post) }
+            from absurd hb_valid (h_1 ha_valid') }
           <|>
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h,
             from absurd hb_valid (h ha_valid) }
@@ -392,10 +392,10 @@ instance hmul.is_simple
             simp only [Stream.mul_ready],
             intro prev_mul_ready,
             cases prev_mul_ready.ready with ha_ready hb_ready,
-            have ha_ready_post := ready_le ha_ready,
+            have ha_ready' := ready_le ha_ready,
             exact {
-              valid := and.intro ha_valid_post hb_valid,
-              ready := and.intro ha_ready_post hb_ready,
+              valid := and.intro ha_valid' hb_valid,
+              ready := and.intro ha_ready' hb_ready,
               index := _,
             },
             have := prev_mul_ready.index,
@@ -405,7 +405,7 @@ instance hmul.is_simple
         -- Various impossible cases (either a or b is invalid).
         all_goals {
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h_1,
-            from absurd hb_valid (h_1 ha_valid_post) }
+            from absurd hb_valid (h_1 ha_valid') }
           <|>
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h,
             from absurd hb_valid (h ha_valid) }
@@ -441,7 +441,7 @@ instance hmul.is_simple
       replace valid_eq : b.valid r.snd ↔ b.valid (b.next r.snd hb_valid) :=
         by simpa only [bool_not_iff, bool.of_to_bool_iff, bool.to_bool_not, bool.to_bool_eq] using valid_eq,
 
-      have hb_valid_post : b.valid (b.next r.snd _) := valid_eq.mp hb_valid,
+      have hb_valid' : b.valid (b.next r.snd _) := valid_eq.mp hb_valid,
 
       rw prod_le_iff at |- hh,
       right, rw prod_le_iff,
@@ -496,7 +496,7 @@ instance hmul.is_simple
         -- Various impossible cases (either a or b is invalid).
         all_goals {
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h_1,
-            from absurd hb_valid_post (h_1 ha_valid) }
+            from absurd hb_valid' (h_1 ha_valid) }
           <|>
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h,
             from absurd hb_valid (h ha_valid) }
@@ -520,10 +520,10 @@ instance hmul.is_simple
             simp only [Stream.mul_ready],
             intro prev_mul_ready,
             cases prev_mul_ready.ready with ha_ready hb_ready,
-            have hb_ready_post := ready_le hb_ready,
+            have hb_ready' := ready_le hb_ready,
             exact {
-              valid := and.intro ha_valid hb_valid_post,
-              ready := and.intro ha_ready hb_ready_post,
+              valid := and.intro ha_valid hb_valid',
+              ready := and.intro ha_ready hb_ready',
               index := _,
             },
             have := prev_mul_ready.index,
@@ -533,7 +533,7 @@ instance hmul.is_simple
         -- Various impossible cases (either a or b is invalid).
         all_goals {
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h_1,
-            from absurd hb_valid_post (h_1 ha_valid) }
+            from absurd hb_valid' (h_1 ha_valid) }
           <|>
           { simp only [Stream.mul_index, Stream.mul_valid, not_and] at h,
             from absurd hb_valid (h ha_valid) }

--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -273,27 +273,7 @@ end
 lemma prod_le_iff {α₁ β₁} [has_lt α₁] [has_le β₁] (a b : α₁ ×ₗ β₁) :
   a ≤ b ↔
     a.1 < b.1 ∨
-    a.1 = b.1 ∧ a.2 ≤ b.2 := begin
-
-  split,
-  {
-    intro h,
-    cases iff.mp (prod.lex_def _ _) h,
-    { left, assumption },
-    { cases h_1 with fst_eq snd_le,
-      right,
-      exact and.intro fst_eq snd_le }
-  },
-  {
-    intro h,
-    apply iff.mpr (prod.lex_def _ _),
-    cases h,
-    { left, assumption },
-    { cases h with fst_eq snd_le,
-      right,
-      exact and.intro fst_eq snd_le }
-  }
-end
+    a.1 = b.1 ∧ a.2 ≤ b.2 := prod.lex_def _ _
 
 lemma bool_not_iff (a b : bool) : !a = !b ↔ a = b := begin
   split,

--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -334,34 +334,31 @@ instance hmul.is_simple
         { -- a and b remain valid.
           rw with_top.coe_eq_coe at ⊢,
           rw with_top.coe_lt_coe at ⊢ idx_lt,
-          cases a_lags,
-          { -- a's index < b's
-            cases em (b.index r.snd _ < a.index (a.next r.fst _) _) with idx'_gt idx'_le,
-            { -- a's new index > b's
-              left,
-              show (a.mul b).index r _ < (a.mul b).index r' _,
-                simp only [Stream.mul_index, with_top.coe_lt_coe, max_lt_iff],
-                split; apply lt_max_iff.mpr; left; assumption
-            },
-            { -- a's new index ≤ b's
-              right,
-              simp only [not_lt] at idx'_le,
-              simp only [bool.le_iff_imp, bool.of_to_bool_iff],
-              split,
+          cases em (b.index r.snd _ < a.index (a.next r.fst _) _) with idx'_gt idx'_le,
+          { -- a's new index > b's
+            left,
+            show (a.mul b).index r _ < (a.mul b).index r' _,
+              simp only [Stream.mul_index, with_top.coe_lt_coe, max_lt_iff],
+              split; apply lt_max_iff.mpr; left; assumption
+          },
+          { -- a's new index ≤ b's
+            right,
+            simp only [not_lt] at idx'_le,
+            simp only [bool.le_iff_imp, bool.of_to_bool_iff],
+            split,
 
-              show (a.mul b).index r _ = (a.mul b).index r' _,
-                simp only [Stream.mul_index, with_top.coe_eq_coe],
-                rw max_eq_right idx'_le,
-                rw max_eq_right (has_le.le.trans (le_of_lt idx_lt) idx'_le),
+            show (a.mul b).index r _ = (a.mul b).index r' _,
+              simp only [Stream.mul_index, with_top.coe_eq_coe],
+              rw max_eq_right idx'_le,
+              rw max_eq_right (has_le.le.trans (le_of_lt idx_lt) idx'_le),
 
-              show (a.mul b).ready r → (a.mul b).ready r',
-                suffices : ¬(a.mul b).ready r,
-                  intro h, from absurd h this,
-                simp only [Stream.mul_ready],
-                have : a.index r.fst _ < b.index r.snd _ :=
-                  has_lt.lt.trans_le idx_lt idx'_le,
-                intro h, from absurd h.index (ne_of_lt this),
-            }
+            show (a.mul b).ready r → (a.mul b).ready r',
+              suffices : ¬(a.mul b).ready r,
+                intro h, from absurd h this,
+              simp only [Stream.mul_ready],
+              have : a.index r.fst _ < b.index r.snd _ :=
+                has_lt.lt.trans_le idx_lt idx'_le,
+              intro h, from absurd h.index (ne_of_lt this),
           }
         },
 
@@ -392,14 +389,16 @@ instance hmul.is_simple
             simp only [Stream.mul_ready],
             intro prev_mul_ready,
             cases prev_mul_ready.ready with ha_ready hb_ready,
-            have ha_ready' := ready_le ha_ready,
+
+            have ha_ready' : a.ready (a.next r.fst _) := ready_le ha_ready,
             exact {
-              valid := and.intro ha_valid' hb_valid,
-              ready := and.intro ha_ready' hb_ready,
-              index := _,
-            },
-            have := prev_mul_ready.index,
-            transitivity; { symmetry, assumption } <|> assumption
+              valid := ⟨ha_valid', hb_valid⟩,
+              ready := ⟨ha_ready', hb_ready⟩,
+              index := begin
+                have := prev_mul_ready.index,
+                transitivity; { symmetry, assumption } <|> assumption
+              end,
+            }
         },
 
         -- Various impossible cases (either a or b is invalid).
@@ -462,34 +461,31 @@ instance hmul.is_simple
         { -- a and b remain valid.
           rw with_top.coe_eq_coe at ⊢,
           rw with_top.coe_lt_coe at ⊢ idx_lt,
-          cases b_lags,
-          { -- b's index < a's
-            cases em (a.index r.fst _ < b.index (b.next r.snd _) _) with idx'_gt idx'_le,
-            { -- b's new index > a's
-              left,
-              show (a.mul b).index r _ < (a.mul b).index r' _,
-                simp only [Stream.mul_index, with_top.coe_lt_coe, max_lt_iff],
-                split; apply lt_max_iff.mpr; right; assumption
-            },
-            { -- b's new index ≤ a's
-              right,
-              simp only [not_lt] at idx'_le,
-              simp only [bool.le_iff_imp, bool.of_to_bool_iff],
-              split,
+          cases em (a.index r.fst _ < b.index (b.next r.snd _) _) with idx'_gt idx'_le,
+          { -- b's new index > a's
+            left,
+            show (a.mul b).index r _ < (a.mul b).index r' _,
+              simp only [Stream.mul_index, with_top.coe_lt_coe, max_lt_iff],
+              split; apply lt_max_iff.mpr; right; assumption
+          },
+          { -- b's new index ≤ a's
+            right,
+            simp only [not_lt] at idx'_le,
+            simp only [bool.le_iff_imp, bool.of_to_bool_iff],
+            split,
 
-              show (a.mul b).index r _ = (a.mul b).index r' _,
-                simp only [Stream.mul_index, with_top.coe_eq_coe],
-                rw max_eq_left idx'_le,
-                rw max_eq_left (has_le.le.trans (le_of_lt idx_lt) idx'_le),
+            show (a.mul b).index r _ = (a.mul b).index r' _,
+              simp only [Stream.mul_index, with_top.coe_eq_coe],
+              rw max_eq_left idx'_le,
+              rw max_eq_left (has_le.le.trans (le_of_lt idx_lt) idx'_le),
 
-              show (a.mul b).ready r → (a.mul b).ready r',
-                suffices : ¬(a.mul b).ready r,
-                  intro h, from absurd h this,
-                simp only [Stream.mul_ready],
-                have : b.index r.snd _ < a.index r.fst _ :=
-                  has_lt.lt.trans_le idx_lt idx'_le,
-                intro h, from absurd h.index (ne.symm (ne_of_lt this)),
-            }
+            show (a.mul b).ready r → (a.mul b).ready r',
+              suffices : ¬(a.mul b).ready r,
+                intro h, from absurd h this,
+              simp only [Stream.mul_ready],
+              have : b.index r.snd _ < a.index r.fst _ :=
+                has_lt.lt.trans_le idx_lt idx'_le,
+              intro h, from absurd h.index (ne.symm (ne_of_lt this)),
           }
         },
 
@@ -520,14 +516,16 @@ instance hmul.is_simple
             simp only [Stream.mul_ready],
             intro prev_mul_ready,
             cases prev_mul_ready.ready with ha_ready hb_ready,
-            have hb_ready' := ready_le hb_ready,
+
+            have hb_ready' : b.ready (b.next r.snd _) := ready_le hb_ready,
             exact {
-              valid := and.intro ha_valid hb_valid',
-              ready := and.intro ha_ready hb_ready',
-              index := _,
-            },
-            have := prev_mul_ready.index,
-            transitivity; { symmetry, assumption } <|> assumption
+              valid := ⟨ha_valid, hb_valid'⟩,
+              ready := ⟨ha_ready, hb_ready'⟩,
+              index := begin
+                have := prev_mul_ready.index,
+                transitivity; { symmetry, assumption } <|> assumption
+              end,
+            }
         },
 
         -- Various impossible cases (either a or b is invalid).

--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -225,14 +225,14 @@ begin
   generalize hb : b.bound = n₂,
   induction n₁ with _ _ c d e f g h generalizing a n₂ b;
   induction n₂ with _ _ k l m n o p generalizing b,
-  { apply bound_valid_aux.invalid, simp [*] at * },
-  { apply bound_valid_aux.invalid, simp [*] at * },
-  { apply bound_valid_aux.invalid, simp [*] at * },
+  { apply bound_valid_aux.start, simp [bound_valid, *] at * },
+  { apply bound_valid_aux.start, simp [bound_valid, *] at * },
+  { apply bound_valid_aux.start, simp [bound_valid, *] at * },
   {
     cases em a.valid; cases em b.valid,
     { simp only [StreamExec.mul_bound, bound_valid, *],
       have : (a ⋆ b).valid, { simp, split; assumption },
-      apply bound_valid_aux.next_bound_valid this,
+      apply bound_valid_aux.step this,
       simp only [delta_succ],
       cases em (a ⊑ b) with ale nale,
       { rw le_succ_left,
@@ -259,9 +259,9 @@ begin
         { assumption }
       },
     },
-    { apply bound_valid_aux.invalid, simp [*] },
-    { apply bound_valid_aux.invalid, simp [*] },
-    { apply bound_valid_aux.invalid, simp [*] } }
+    { apply bound_valid_aux.start, simp [StreamExec.valid, *] at * },
+    { apply bound_valid_aux.start, simp [StreamExec.valid, *] at * },
+    { apply bound_valid_aux.start, simp [StreamExec.valid, *] at * } }
 end
 
 #check prod.lex_def

--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -287,9 +287,7 @@ instance hmul.is_simple
 { monotonic := begin
     intros r h,
     cases h with ha_valid hb_valid,
-    simp only [Stream.mul_next],
-
-    simp only [StreamState.lag] at *,
+    simp only [Stream.mul_next, StreamState.lag],
 
     split_ifs with a_lags b_lags,
     { -- a lags b; we increase a


### PR DESCRIPTION
No more `sorry`s in `hmul.is_simple`!

A few outstanding questions:

- <s>The monotonicity proof is super slow to check, probably because I made liberal use of `simp at *`. I tried to use `simp only` instead, but I couldn't find the names of some lemmas that `simp` automatically applies.</s>

  After changing all the `simp`s to `simp only`, the proof now takes around 7 sec to check, which seems good enough.

- The two major sections – whether `a` lags `b` or `b` lags `a` – are almost identical (except for swapping `fst` and `snd`, etc.). I didn't try to coalesce them, but doing so would probably make the proof prettier.

- Is there a way to avoid writing out the lemma prod_le_iff, and use prod.lex_def directly instead?

  For reference:
  ```lean
  prod.lex_def :      -- in mathlib
  ∀ (r : α → α → Prop) (s : β → β → Prop) {a b : α × β},
    prod.lex r s a b ↔
      r a.1 b.1 ∨
      a.1 = b.1 ∧ s p.2 q.2

  instance has_le (α β : Type*) [has_lt α] [has_le β] : has_le (α ×ₗ β) :=
  { le := prod.lex (<) (≤) }

  prod_le_iff :       -- defined by me
  ∀ (a b : α ×ₗ β),
    a ≤ b ↔
      a.1 < b.1 ∨
      a.1 = b.1 ∧ a.2 ≤ b.2
  ```