### PR TITLE
Update mathlib and Lean

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "etch"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.42.1"
+lean_version = "leanprover-community/lean:3.49.1"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "9503f73336f35b9e1e0c1b3a37a364768187749f"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "955890d374bb632cd662a1ca51a5a6a11c39578f"}

--- a/src/compile_fast.lean
+++ b/src/compile_fast.lean
@@ -333,7 +333,7 @@ def mul [has_hmul α β γ] (a : G E α) (b : G E β) : G E γ :=
                         a.next
                         b.next,
   valid := a.valid && b.valid,
-  init  := a.init;; b.init,
+  init  := a.init; b.init,
 }
 instance [has_hmul α β γ] : has_hmul (G E α) (G E β) (G E γ) := ⟨mul⟩
 

--- a/src/compile_fast.lean
+++ b/src/compile_fast.lean
@@ -74,7 +74,7 @@ def neg : E → E
 
 infixr ` <;> `:1 := Prog.seq
 infixr ` ;; `:1 := Prog.seq
-infixr ` ; `:1 := Prog.seq
+infixr (name := seq) ` ; `:1 := Prog.seq
 --instance : has_andthen Prog Prog Prog := ⟨Prog.seq⟩
 
 instance : has_zero E := ⟨E.lit 0⟩
@@ -286,14 +286,14 @@ section G
 
 variables {α ι γ β : Type}
 
-local infixl ` && `:70 := BinOp.and
-local infixl ` || `:65 := BinOp.or
-local infix  ` < `:71  := BinOp.lt
-infix  ` == `:71 := BinOp.eq
-infix  ` === `:71 := BinOp.lit_eq
-infix  ` != `:71 := λ a b, (BinOp.eq a b).neg
+local infixl (name := and) ` && `:70 := BinOp.and
+local infixl (name := or)  ` || `:65 := BinOp.or
+local infix  (name := lt)  ` < `:71  := BinOp.lt
+infix  (name := eq)  ` == `:71 := BinOp.eq
+infix  (name := teq) ` === `:71 := BinOp.lit_eq
+infix  (name := ne)  ` != `:71 := λ a b, (BinOp.eq a b).neg
 @[pattern] def E.le : E → E → E := λ a b, BinOp.or (a < b) (a == b)
-local infix  ` ≤ `:71  := E.le
+local infix  (name := le) ` ≤ `:71  := E.le
 
 --notation e `⟦` k `⟧` := e.access k
 
@@ -308,7 +308,7 @@ def G.empty [inhabited ι] [inhabited α] : G ι α :=
 structure View (ι α : Type) := (value : ι → α)
 
 def constView (ι : Type) (v : α) : View ι α := ⟨λ _, v⟩
-prefix ` ⇑ ` := constView
+prefix (name := const) ` ⇑ ` := constView
 -- instance : has_coe (α → β) (View α β) := ⟨View.mk⟩
 
 instance {ι : Type*} : functor (G ι) :=
@@ -333,19 +333,19 @@ def mul [has_hmul α β γ] (a : G E α) (b : G E β) : G E γ :=
                         a.next
                         b.next,
   valid := a.valid && b.valid,
-  init  := a.init; b.init,
+  init  := a.init;; b.init,
 }
 instance [has_hmul α β γ] : has_hmul (G E α) (G E β) (G E γ) := ⟨mul⟩
 
-instance scalar_G [has_scalar E α] : has_scalar E (G E α) :=
+instance smul_G [has_smul E α] : has_smul E (G E α) :=
 ⟨λ s v, { v with value := s • v.value } ⟩
-instance scalar_unit [has_scalar E α] : has_scalar E (G unit α) :=
+instance smul_unit [has_smul E α] : has_smul E (G unit α) :=
 ⟨λ s v, { v with value := s • v.value } ⟩
-instance scalar_base [has_hmul E α α] : has_scalar E α := ⟨(⋆)⟩
+instance smul_base [has_hmul E α α] : has_smul E α := ⟨(⋆)⟩
 
-example : has_scalar E E := infer_instance
+example : has_smul E E := infer_instance
 
-def add [has_scalar E α] [has_mul α] [has_add α] (a b : G E α) : G E α :=
+def add [has_smul E α] [has_mul α] [has_add α] (a b : G E α) : G E α :=
 let current := BinOp.min a.index b.index in
 { index := current,
   value := (a.index == current) • a.value + (b.index == current) • b.value,
@@ -361,7 +361,7 @@ let current := BinOp.min a.index b.index in
   init  := a.init; b.init,
 }
 
-instance [has_mul α] [has_scalar E α] [has_add α] : has_add (G E α) := ⟨add⟩
+instance [has_mul α] [has_smul E α] [has_add α] : has_add (G E α) := ⟨add⟩
 
 def mul_unit_const_r [has_hmul α β γ] (a : G unit α) (b : β) : G unit γ := (⋆ b) <$> a
 def mul_unit_const_l [has_hmul α β γ] (a : α) (b : G unit β) : G unit γ := (λ v, a ⋆ v) <$> b

--- a/src/finsupp_lemmas.lean
+++ b/src/finsupp_lemmas.lean
@@ -1,3 +1,4 @@
+import data.finsupp.basic
 import data.finsupp.indicator
 
 variables {α β γ : Type*} [add_comm_monoid β]

--- a/src/verification/misc.lean
+++ b/src/verification/misc.lean
@@ -1,10 +1,11 @@
-import data.option.basic
 import data.fin.tuple.basic
-import data.pfun
-import data.list.basic
 import data.finsupp.basic
-import data.list.range
 import data.finsupp.pointwise
+import data.list.basic
+import data.list.range
+import data.option.basic
+import data.pfun
+import data.prod.lex
 
 lemma bool.coe_iff_eq_tt (b : bool) : b ↔ b = tt := iff.rfl
 @[simp] lemma option.bind_const_none {α β} (x : option α) :
@@ -72,10 +73,6 @@ by { rw ← not_iff_not, simp [option.is_none_iff_eq_none], }
 @[simp] lemma option.map_is_some' {α β} (x : option α) (f : α → β) :
   (x.map f).is_some = x.is_some := by cases x; simp
 
-/-- This lemma is in updated version of mathlib -/
-lemma list.some_nth_le_eq {α} {l : list α} {n : ℕ} {h} : some (l.nth_le n h) = l.nth n :=
-by { symmetry, rw list.nth_eq_some, exact ⟨_, rfl⟩, }
-
 lemma list.zip_with_fst {α β} {l₁ : list α} {l₂ : list β} (hl : l₁.length ≤ l₂.length) :
   list.zip_with (λ a b, a) l₁ l₂ = l₁ :=
 by { erw [← list.map_uncurry_zip_eq_zip_with, list.map_fst_zip], exact hl, }
@@ -84,15 +81,9 @@ lemma list.zip_with_snd {α β} {l₁ : list α} {l₂ : list β} (hl : l₂.len
   list.zip_with (λ a b, b) l₁ l₂ = l₂ :=
 by { erw [← list.map_uncurry_zip_eq_zip_with, list.map_snd_zip], exact hl, }
 
-/-- This lemma is in the most updated version of mathlib -/
-@[simp] lemma list.map_nth_le {α} (l : list α) :
-  (list.fin_range l.length).map (λ n, l.nth_le n n.2) = l :=
-list.ext_le (by rw [list.length_map, list.length_fin_range]) $ λ n _ h,
-by { rw ← list.nth_le_map_rev, congr, { rw list.nth_le_fin_range, refl }, { rw list.length_fin_range, exact h } }
-
 @[simp] lemma multiset.map_nth_le {α} {n : ℕ} {l : list α} (hn : l.length = n) :
     (finset.univ.val : multiset (fin n)).map (λ i, l.nth_le i (by rw hn; exact i.prop)) = l :=
-by { subst hn, simp [finset.univ, fintype.elems, finset.fin_range], erw list.map_nth_le, }
+by { subst hn, simp [finset.univ, fintype.elems], erw list.map_nth_le, }
 
 @[simp] lemma le_ff_iff {b : bool} : b ≤ ff ↔ b = ff :=
 by cases b; simp
@@ -102,7 +93,7 @@ lemma ne_min_of_ne_and_ne {ι : Type*} [linear_order ι] {a x y : ι} (hx : a �
 
 @[simp] lemma max_ne_self_iff {ι : Type*} [linear_order ι] (a b : ι) :
   ¬(a = max a b) ↔ a < b :=
-by { simp [max_def, ← not_lt], split_ifs; simp [h], exact h.ne, }
+by { simp [max_def, ← not_lt], split_ifs, { simp [h, le_of_lt h] }, { simp [h, le_of_not_lt h] } }
 
 @[simp] lemma max_ne_self_iff' {ι : Type*} [linear_order ι] (a b : ι) :
   ¬(b = max a b) ↔ b < a :=

--- a/src/verification/misc.lean
+++ b/src/verification/misc.lean
@@ -93,7 +93,7 @@ lemma ne_min_of_ne_and_ne {ι : Type*} [linear_order ι] {a x y : ι} (hx : a �
 
 @[simp] lemma max_ne_self_iff {ι : Type*} [linear_order ι] (a b : ι) :
   ¬(a = max a b) ↔ a < b :=
-by { simp [max_def, ← not_lt], split_ifs, { simp [h, le_of_lt h] }, { simp [h, le_of_not_lt h] } }
+by { rw max_def, split_ifs, { simpa using h }, { simpa using le_of_not_ge h } }
 
 @[simp] lemma max_ne_self_iff' {ι : Type*} [linear_order ι] (a b : ι) :
   ¬(b = max a b) ↔ b < a :=

--- a/src/verification/stream_replicate.lean
+++ b/src/verification/stream_replicate.lean
@@ -74,7 +74,7 @@ begin
   intros r hv hr,
   rw [Stream.index'_val hv, Stream.index'],
   split_ifs,
-  { simp [fin.ext_iff] },
+  { dunfold Stream.replicate, simp },
   { simp }
 end
 
@@ -102,12 +102,12 @@ def SimpleStream.replicate (n : ℕ) (v : α) : SimpleStream (fin n) α :=
 namespace finsupp
 
 noncomputable def const {ι : Type} [fintype ι] (v : α) : ι →₀ α :=
-equiv_fun_on_fintype.inv_fun $ λ _, v
+equiv_fun_on_finite.inv_fun $ λ _, v
 
 end finsupp
 
 noncomputable def replicate_aux (n : ℕ) (v : α) (r : fin n.succ) : fin n →₀ α :=
-finsupp.equiv_fun_on_fintype.inv_fun $ λ i, if i.val ≥ r.val then v else 0
+finsupp.equiv_fun_on_finite.inv_fun $ λ i, if i.val ≥ r.val then v else 0
 
 lemma replicate_aux.const : replicate_aux n v 0 = finsupp.const v :=
 begin
@@ -128,15 +128,15 @@ begin
   ext i,
   cases i with i i_prop,
   cases r with r r_prop, change r < n at h,
-  simp [replicate_aux, finsupp.single], -- TODO: don't simp mid-proof
+  simp [replicate_aux, finsupp.single, pi.single_apply], -- TODO: don't simp mid-proof
   split_ifs,
   { exfalso, revert h_1, simp [h_2] },
-  { have : r ≤ i := le_of_eq h_2,           contradiction },
+  { have : r ≤ i := le_of_eq (eq.symm h_2), contradiction },
   { exact add_zero _ },
   { have : r ≤ i := nat.le_of_succ_le h_1,  contradiction },
   { exact zero_add _ },
-  { have : r ≤ i := le_of_eq h_2,           contradiction },
-  { have : r < i := lt_of_le_of_ne h_3 h_2, contradiction },
+  { have : r ≤ i := le_of_eq (eq.symm h_2), contradiction },
+  { have : r < i := lt_of_le_of_ne h_3 (ne.symm h_2), contradiction },
   { exact add_zero _ }
 end
 

--- a/src/verification/stream_replicate.lean
+++ b/src/verification/stream_replicate.lean
@@ -131,11 +131,11 @@ begin
   simp [replicate_aux, finsupp.single, pi.single_apply], -- TODO: don't simp mid-proof
   split_ifs,
   { exfalso, revert h_1, simp [h_2] },
-  { have : r ≤ i := le_of_eq (eq.symm h_2), contradiction },
+  { have : r ≤ i := le_of_eq h_2.symm,      contradiction },
   { exact add_zero _ },
   { have : r ≤ i := nat.le_of_succ_le h_1,  contradiction },
   { exact zero_add _ },
-  { have : r ≤ i := le_of_eq (eq.symm h_2), contradiction },
+  { have : r ≤ i := le_of_eq h_2.symm,      contradiction },
   { have : r < i := lt_of_le_of_ne h_3 (ne.symm h_2), contradiction },
   { exact add_zero _ }
 end

--- a/src/verification/test.lean
+++ b/src/verification/test.lean
@@ -11,7 +11,7 @@ open Eval (eval)
 
 local notation ` ∑ᵢ ` s := s.contract
 
-local notation a ` && ` b := a + b
+local notation (name := bool_add) a ` && ` b := a + b
 
 -- 
 noncomputable instance SimpleStream.AddZeroEval_weird :

--- a/src/verification/vars.lean
+++ b/src/verification/vars.lean
@@ -2,6 +2,7 @@ import tactic.derive_fintype
 import logic.function.basic
 import data.set.function
 import data.fin.tuple
+import data.finset.lattice
 
 section vars
 @[derive decidable_eq, derive fintype, derive inhabited]
@@ -29,8 +30,8 @@ theorem not_fresh_mem (S : finset NameSpace) : fresh S ∉ S :=
 begin
   simp only [fresh],
   cases hn : S.max,
-  { rw [finset.max_eq_none] at hn, subst hn, exact finset.not_mem_empty _, },
-  intro h, simpa using finset.le_max_of_mem h hn,
+  { rw finset.max_eq_bot.1 hn, exact finset.not_mem_empty _, },
+  { refine finset.not_mem_of_max_lt _ hn, simp },
 end
 
 theorem not_fresh_reserved (S : finset NameSpace) : fresh S ≠ NameSpace.reserved :=


### PR DESCRIPTION
I wanted to use some monotonicity lemmas for `with_top`, but our mathlib is too old, and there have been too many changes to cherry pick.

Every file in src/verification/ except verify.lean continues to type-check. src/compile\_fast.lean type checks too.
