### PR TITLE
Split streams with tuple index

### DIFF
--- a/src/verification/stream.lean
+++ b/src/verification/stream.lean
@@ -129,6 +129,7 @@ lemma Stream.eval₀_support [has_zero α] (s : Stream ι α) (x : s.σ) (h : s.
   (s.eval₀ x h).support ⊆ {s.index x h} :=
 by { rw Stream.eval₀, split_ifs, { exact finsupp.support_single_subset, }, simp, }
 
+-- See also [Stream.bound_valid_iterate] later
 @[simp] lemma Stream.bound_valid_succ {s : Stream ι α} {n : ℕ} {σ₀ : s.σ} :
   s.bound_valid (n + 1) σ₀ ↔ (∀ (h : s.valid σ₀), s.bound_valid n (s.next σ₀ h)) :=
 ⟨λ h, by { cases h, { intro, contradiction, }, intro, assumption, }, λ h, if H : s.valid σ₀ then step H (h H) else start _ H⟩
@@ -215,11 +216,11 @@ lemma Stream.index'_invalid {s : Stream ι α} {x : s.σ} (h : ¬s.valid x) : s.
 
 lemma Stream.value'_val [has_zero α] {s : Stream ι α} {x : s.σ} (h : s.ready x) : s.value' x = s.value x h := dif_pos h
 
-lemma Stream.next'_val {s : Stream ι α} {x : s.σ} (hx) : s.next' x = s.next x hx := dif_pos hx
+@[simp] lemma Stream.next'_val {s : Stream ι α} {x : s.σ} (hx) : s.next' x = s.next x hx := dif_pos hx
 
-lemma Stream.next'_val_invalid {s : Stream ι α} {x : s.σ} (hx : ¬s.valid x) : s.next' x = x := dif_neg hx
+@[simp] lemma Stream.next'_val_invalid {s : Stream ι α} {x : s.σ} (hx : ¬s.valid x) : s.next' x = x := dif_neg hx
 
-lemma Stream.next'_val_invalid' {s : Stream ι α} {x : s.σ} (hx : ¬s.valid x) (n : ℕ) :
+@[simp] lemma Stream.next'_val_invalid' {s : Stream ι α} {x : s.σ} (hx : ¬s.valid x) (n : ℕ) :
   s.next'^[n] x = x := function.iterate_fixed (Stream.next'_val_invalid hx) n
 
 lemma Stream.next'_valid {s : Stream ι α} {x : s.σ}
@@ -239,6 +240,10 @@ lemma bound_valid_iff_next'_iterate {s : Stream ι α} {x : s.σ} {n : ℕ} :
   s.bound_valid n x ↔ ¬s.valid (s.next'^[n] x) :=
 by { induction n with n ih generalizing x, { simp, }, by_cases H : s.valid x; simp [ih, H, Stream.next'_val, Stream.next'_val_invalid, Stream.next'_val_invalid'], }
 
+lemma Stream.bound_valid_iterate {s : Stream ι α} {n N : ℕ} {σ₀ : s.σ} :
+  s.bound_valid (n + N) σ₀ ↔ s.bound_valid n (s.next'^[N] σ₀) :=
+by simp_rw [bound_valid_iff_next'_iterate, function.iterate_add_apply]
+
 theorem Stream.no_repeat_if_bound_valid' {s : Stream ι α} {x : s.σ} {B : ℕ}
   (bv : s.bound_valid B x) (h : s.valid x) : ∀ (n : ℕ), s.next'^[n.succ] x ≠ x :=
 begin
@@ -246,7 +251,7 @@ begin
   cases bv with k rep,
   induction B with B ih generalizing x,
   { simpa },
-  { suffices : ¬Stream.bound_valid B s (s.next' x), by simpa [h, ← Stream.next'_val h] using this,
+  { suffices : ¬s.bound_valid B (s.next' x), by simpa [h] using this,
     apply ih,
     { rw [function.iterate_succ_apply] at rep,
       have h' := h, rw ← rep at h',

--- a/src/verification/stream_multiply.lean
+++ b/src/verification/stream_multiply.lean
@@ -159,7 +159,7 @@ begin
   apply Stream.mul_induction ha hb (λ x y k₁ k₂ N, (a * b).eval_steps N (x, y) = (a.eval_steps k₁ x) * (b.eval_steps k₂ y)); clear_except hsa hsb,
   { intros, simp, },
   { intros x y B₁ B₂ N H h ha hb,
-    cases h; simp [Stream.eval_invalid h, Stream.eval_invalid H, Stream.next'_val_invalid' H], },
+    cases h; simp [H, Stream.eval_invalid h, Stream.eval_invalid H], },
   { intros x y k₁ k₂ n H h he,
     simp [H, H.1, h, he, add_mul], congr,
     simp [H.2, mul_add, Stream.mul_eq_zero hsb H.1 H.2 h, Stream.mul_eval₀], },

--- a/src/verification/stream_split.lean
+++ b/src/verification/stream_split.lean
@@ -1,0 +1,87 @@
+import verification.stream_props
+
+section
+variables {α ι ι₁ ι₂ : Type}
+{n : ℕ} {v : α}
+
+open_locale classical
+
+-- valid as long as the current index is in w
+@[simps]
+def substream (s : Stream ι α) (w : set ι) : Stream ι α :=
+{ σ := s.σ,
+  valid := λ p, ∃ h, s.index p h ∈ w,
+  ready := λ p, s.ready p,
+  next := λ p h, s.next p h.fst,
+  index := λ p h, s.index p h.fst,
+  value := λ p h, s.value p h,
+}
+
+-- lemma substream.state_eq (s : Stream ι α) (w : set ι) :
+-- ∀ n x, s.next'^[n] = (substream s w).next'^[n]
+
+lemma substream.bound_valid (s : Stream ι α) (B x) :
+s.bound_valid B x → ∀ w, (substream s w).bound_valid B x :=
+begin
+  simp_rw bound_valid_iff_next'_iterate,
+  induction B generalizing x,
+  { simp_rw [function.iterate_zero_apply, substream_valid, not_exists],
+    intros,
+    contradiction },
+  { by_cases s.valid (s.next'^[B_n] x); intros hnv w,
+    { simp_rw [function.iterate_succ_apply'], sorry },
+    { sorry } }
+end
+
+@[simps]
+def Stream.split (r : ι → ι → Prop) (s : StreamExec ι α) : Stream (quot r) (StreamExec ι α) :=
+{ σ := s.stream.σ × option (quot r), -- keep track of the last element seen
+  valid := λ p, s.stream.valid p.1,
+  ready := λ p, s.stream.ready p.1 ∧
+                s.stream.bound_valid s.bound p.1 ∧ -- this is weird
+                ∃ hv, p.2 ≠ quot.mk r (s.stream.index p.1 hv),
+  next := λ p h, (s.stream.next p.1 h, quot.mk r (s.stream.index p.1 h)),
+  index := λ p h, quot.mk r (s.stream.index p.1 h),
+  value := λ p h, {
+    stream := substream s.stream (r (s.stream.index p.1 h.2.2.fst)),
+    state := p.1,
+    bound := s.bound,
+    bound_valid := begin
+      have := h.2.1,
+      sorry
+    end,
+  },
+}
+
+lemma Stream.split_state {r} {s : StreamExec ι α} {prev} :
+∀ (x: s.stream.σ) n,
+((Stream.split r s).next'^[n] (x, prev)).1 = (s.stream.next'^[n] x) :=
+begin
+  intros,
+  induction n with _ ih generalizing x prev,
+  { simp },
+  { simp_rw function.iterate_succ_apply,
+    rw ← ih (s.stream.next' x),
+    suffices : (s.stream.next' x, _) = (Stream.split r s).next' (x, prev), by rw this,
+    suffices : s.stream.next' x = ((Stream.split r s).next' (x, prev)).1, by ext; simp [this],
+    unfold Stream.next',
+    split_ifs,
+    { dunfold Stream.split, simp },
+    { simp } }
+end
+
+def StreamExec.split (r : ι → ι → Prop) (s : StreamExec ι α) : StreamExec (quot r) (StreamExec ι α) :=
+{ stream := Stream.split r s,
+  state := (s.state, none),
+  bound := s.bound,
+  bound_valid := begin
+    have bv := s.bound_valid,
+    rw bound_valid_iff_next'_iterate at ⊢ bv,
+    induction eq : s.bound,
+    { simpa [eq] using bv },
+    { simp_rw [Stream.split_valid, Stream.split_state],
+      simpa [eq] using bv }
+  end,
+}
+
+end


### PR DESCRIPTION
- Adds `Stream.split`, `StreamExec.split`
  - Includes proof for bound-validity
- States (part of) spec; no proof yet
- Some helper lemmas for bound-validity
